### PR TITLE
RESOLVED :  Room ID and Username Validation Allows Whitespace Input

### DIFF
--- a/client/src/components/forms/FormComponent.tsx
+++ b/client/src/components/forms/FormComponent.tsx
@@ -29,16 +29,16 @@ const FormComponent = () => {
     }
 
     const validateForm = () => {
-        if (currentUser.username.length === 0) {
+        if (currentUser.username.trim().length === 0) {
             toast.error("Enter your username")
             return false
-        } else if (currentUser.roomId.length === 0) {
+        } else if (currentUser.roomId.trim().length === 0) {
             toast.error("Enter a room id")
             return false
-        } else if (currentUser.roomId.length < 5) {
+        } else if (currentUser.roomId.trim().length < 5) {
             toast.error("ROOM Id must be at least 5 characters long")
             return false
-        } else if (currentUser.username.length < 3) {
+        } else if (currentUser.username.trim().length < 3) {
             toast.error("Username must be at least 3 characters long")
             return false
         }


### PR DESCRIPTION
[Resolved] ISSUE #22 
### Description  
This pull request resolves a bug in the Room ID and Username validation logic. Previously, the application was counting whitespace characters toward the minimum length requirement (5 characters for Room ID and 3 characters for Username). This allowed users to enter only spaces in these fields and bypass the validation, which led to rooms being created or joined with invalid input.

### Changes Made  
- Added `trim()` to the Room ID and Username input fields before validating their lengths. This removes any leading and trailing whitespace, ensuring only non-space characters are counted toward the minimum length requirement.

### Testing  
Tested the updated validation by:
1. Entering a Room ID with only spaces and verifying that an error is shown.
2. Entering a Username with only spaces and verifying that an error is shown.
3. Entering valid Room ID and Username inputs with mixed spaces and characters, which now passes the validation correctly.

### Impact  
This fix prevents users from joining or creating rooms with only spaces as Room ID or Username, ensuring proper input validation as intended.
### Sample Screen Shot of Resolved Bug
![image](https://github.com/user-attachments/assets/84adeb5e-7bc9-4abb-b9a6-3ae5059a40e0)

### Final Result 
https://github.com/user-attachments/assets/68196110-2c05-4558-8761-d8338d5f5a1a
