### PR TITLE
fix(client/src/chats/chatInput.tsx): correct import spelling to resolve component loading issue

### DIFF
--- a/client/src/components/chats/ChatInput.tsx
+++ b/client/src/components/chats/ChatInput.tsx
@@ -5,7 +5,7 @@ import { ChatMessage } from "@/types/chat"
 import { SocketEvent } from "@/types/socket"
 import { formatDate } from "@/utils/formateDate"
 import { FormEvent, useRef } from "react"
-import { LuSendHorizonal } from "react-icons/lu"
+import { LuSendHorizontal } from "react-icons/lu"
 import { v4 as uuidV4 } from "uuid"
 
 function ChatInput() {
@@ -48,7 +48,7 @@ function ChatInput() {
                 className="flex items-center justify-center rounded-r-md  bg-primary p-2 text-black"
                 type="submit"
             >
-                <LuSendHorizonal size={24} />
+                <LuSendHorizontal size={24} />
             </button>
         </form>
     )


### PR DESCRIPTION
This pull request fixes a spelling mistake in the import statement of `chatInput.tsx`. The import for the `LuSendHorizontal` component from `react-icons/lu` was incorrectly written as `LuSendHorizonal`.  

Due to this typo, the React component was not loading during runtime, causing errors. This fix resolves the issue by correcting the spelling, ensuring that the component loads correctly.

Changes:
- Fixed the typo in the import statement: `LuSendHorizonal` -> `LuSendHorizontal`
