### PR TITLE
Configurable Piston API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can view the live preview of the project [here](https://code-sync-live.verce
 
    ```bash
    VITE_BACKEND_URL=<your_server_url>
+   VITE_PISTON_API_URL=<your_piston_instance_api_url>
    ```
 
    Backend:

--- a/client/src/api/pistonApi.ts
+++ b/client/src/api/pistonApi.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from "axios"
 
-const pistonBaseUrl = "https://emkc.org/api/v2/piston"
+const pistonBaseUrl = import.meta.env.VITE_PISTON_API_URL || "http://localhost:2000/api/v2"
 
 const instance: AxiosInstance = axios.create({
     baseURL: pistonBaseUrl,


### PR DESCRIPTION
Unfortunately, `https://emkc.org/api/v2/piston` is no longer available publicly. The API now returns:

> Public Piston API is now whitelist only as of 2/15/2026. Please contact EngineerMan on Discord with use case justification or consider hosting your own Piston instance.

This change adds a configuration option for a custom Piston API URL.