### PR TITLE
 Add persistent rooms: server-side session state with configurable TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,27 +57,39 @@ You can view the live preview of the project [here](https://code-sync-live.verce
    ```bash
    git clone https://github.com/<your-username>/Code-Sync.git
    ```
-3. **Create .env file:**
-   Inside the client and server directories create `.env` and set:
+3. **Configure client:**
 
-   Frontend:
+   The client configuration lives in `client/src/config/`. Copy the sample file and customize as needed:
 
    ```bash
-   VITE_BACKEND_URL=<your_server_url>
-   VITE_PISTON_API_URL=<your_piston_instance_api_url>
+   cp client/src/config/user.sample.ts client/src/config/user.ts
    ```
 
-   Backend:
+   Edit `client/src/config/user.ts` to override any defaults. For example:
+   ```typescript
+   import type { Config } from './defaults'
+
+   const overrides: Partial<Config> = {
+      backendUrl: 'http://localhost:3000',
+      pistonApiUrl: 'http://localhost:2000/api/v2',
+   }
+
+   export default overrides
+   ```
+   All other defaults you can see in `client/src/config/defaults.ts`.
+
+4. **Configure backend:**
+   Create `server/.env` and set:
 
    ```bash
    PORT=3000
    ```
 
-4. **Install dependencies:**
+5. **Install dependencies:**
    ```bash
    npm install     # Run in both client and server directories
    ```
-5. **Start the servers:**
+6. **Start the servers:**
    Frontend:
    ```bash
    cd client
@@ -88,7 +100,7 @@ You can view the live preview of the project [here](https://code-sync-live.verce
    cd server
    npm run dev
    ```
-6. **Access the application:**
+7. **Access the application:**
    ```bash
    http://localhost:5173/
    ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A collaborative, real-time code editor where users can seamlessly code together.
 - 🎨 Multiple themes for personalized coding experience
 - 🎨 Collaborative Drawing: Enable users to draw and sketch collaboratively in real-time
 - 🤖 Copilot: An AI-powered assistant that generates code, allowing you to insert, copy, or replace content seamlessly within your files.
+- 💾 Session persistence: rooms remember their file structure after all users leave (default 1 minute)
 
 ## 🚀 Live Preview
 
@@ -57,7 +58,7 @@ You can view the live preview of the project [here](https://code-sync-live.verce
    ```bash
    git clone https://github.com/<your-username>/Code-Sync.git
    ```
-3. **Configure client:**
+3. **Configure client (optional):**
 
    The client configuration lives in `client/src/config/`. Copy the sample file and customize as needed:
 
@@ -78,11 +79,12 @@ You can view the live preview of the project [here](https://code-sync-live.verce
    ```
    All other defaults you can see in `client/src/config/defaults.ts`.
 
-4. **Configure backend:**
+4. **Configure backend (optional):**
    Create `server/.env` and set:
 
    ```bash
    PORT=3000
+   SESSION_TTL=60   # session TTL in seconds (default 1 minute; Infinity = no cleanup; 0 = disable persistent sessions)
    ```
 
 5. **Install dependencies:**

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -24,6 +24,9 @@ dist-ssr
 *.sw?
 .env
 
+# User config
+src/config/user.ts
+
 # Tailwind output file
 public/style.css
 

--- a/client/package.json
+++ b/client/package.json
@@ -4,10 +4,11 @@
     "version": "0.0.0",
     "type": "module",
     "scripts": {
-        "dev": "vite",
-        "build": "tsc && vite build",
+        "dev": "npm run ensure-user-config && vite",
+        "build": "npm run ensure-user-config && tsc && vite build",
         "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-        "preview": "vite preview --host 0.0.0.0"
+        "preview": "vite preview --host 0.0.0.0",
+        "ensure-user-config": "cp -n src/config/user.sample.ts src/config/user.ts"
     },
     "dependencies": {
         "@uiw/codemirror-extensions-color": "^4.21.21",

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
         "build": "npm run ensure-user-config && tsc && vite build",
         "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
         "preview": "vite preview --host 0.0.0.0",
-        "ensure-user-config": "cp -n src/config/user.sample.ts src/config/user.ts"
+        "ensure-user-config": "cp --update=none src/config/user.sample.ts src/config/user.ts"
     },
     "dependencies": {
         "@uiw/codemirror-extensions-color": "^4.21.21",

--- a/client/src/api/pistonApi.ts
+++ b/client/src/api/pistonApi.ts
@@ -1,9 +1,8 @@
+import config from "@/config"
 import axios, { AxiosInstance } from "axios"
 
-const pistonBaseUrl = import.meta.env.VITE_PISTON_API_URL || "http://localhost:2000/api/v2"
-
 const instance: AxiosInstance = axios.create({
-    baseURL: pistonBaseUrl,
+    baseURL: config.pistonApiUrl,
     headers: {
         "Content-Type": "application/json",
     },

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import SidebarButton from "@/components/sidebar/sidebar-views/SidebarButton"
+import config from "@/config"
 import { useAppContext } from "@/context/AppContext"
 import { useSocket } from "@/context/SocketContext"
 import { useViews } from "@/context/ViewContext"
@@ -6,7 +7,6 @@ import useResponsive from "@/hooks/useResponsive"
 import useWindowDimensions from "@/hooks/useWindowDimensions"
 import { ACTIVITY_STATE } from "@/types/app"
 import { SocketEvent } from "@/types/socket"
-import { VIEWS } from "@/types/view"
 import { IoCodeSlash } from "react-icons/io5"
 import { MdOutlineDraw } from "react-icons/md"
 import cn from "classnames"
@@ -22,6 +22,7 @@ function Sidebar() {
         viewIcons,
         setIsSidebarOpen,
     } = useViews()
+    const visibleTabs = config.visibleTabs
     const { minHeightReached } = useResponsive()
     const { activityState, setActivityState } = useAppContext()
     const { socket } = useSocket()
@@ -52,32 +53,16 @@ function Sidebar() {
                     },
                 )}
             >
-                <SidebarButton
-                    viewName={VIEWS.FILES}
-                    icon={viewIcons[VIEWS.FILES]}
-                />
-                <SidebarButton
-                    viewName={VIEWS.CHATS}
-                    icon={viewIcons[VIEWS.CHATS]}
-                />
-                <SidebarButton
-                    viewName={VIEWS.COPILOT}
-                    icon={viewIcons[VIEWS.COPILOT]}
-                />
-                <SidebarButton
-                    viewName={VIEWS.RUN}
-                    icon={viewIcons[VIEWS.RUN]}
-                />
-                <SidebarButton
-                    viewName={VIEWS.CLIENTS}
-                    icon={viewIcons[VIEWS.CLIENTS]}
-                />
-                <SidebarButton
-                    viewName={VIEWS.SETTINGS}
-                    icon={viewIcons[VIEWS.SETTINGS]}
-                />
+                {visibleTabs.map((viewName) => (
+                    <SidebarButton
+                        key={viewName}
+                        viewName={viewName}
+                        icon={viewIcons[viewName]}
+                    />
+                ))}
 
-                {/* Button to change activity state coding or drawing */}
+                {config.showDrawingToggle && (
+                /* Button to change activity state coding or drawing */
                 <div className="flex h-fit items-center justify-center">
                     <button
                         className="justify-cente flex items-center  rounded p-1.5 transition-colors duration-200 ease-in-out hover:bg-[#3D404A]"
@@ -109,6 +94,7 @@ function Sidebar() {
                         />
                     )}
                 </div>
+                )}
             </div>
             <div
                 className="absolute left-0 top-0 z-20 w-full flex-col bg-dark md:static md:min-w-[300px]"

--- a/client/src/config/defaults.ts
+++ b/client/src/config/defaults.ts
@@ -13,6 +13,13 @@ const config = {
 	defaultFontSize: 16,
 	defaultFontFamily: 'Space Mono',
 	defaultShowGitHubCorner: true,
+	interfaceColors: {
+		dark: "#212429",
+		darkHover: "#3D404A",
+		light: "#f5f5f5",
+		primary: "#39E079",
+		danger: "#ef4444",
+	},
 }
 
 export default config

--- a/client/src/config/defaults.ts
+++ b/client/src/config/defaults.ts
@@ -1,3 +1,5 @@
+import { VIEWS } from "../types/view"
+
 const defaultFileContent = `function sayHi() {
   console.log("👋 Hello world");
 }
@@ -6,13 +8,18 @@ sayHi()`;
 const config = {
 	backendUrl: 'http://localhost:3000',
 	pistonApiUrl: 'http://localhost:2000/api/v2',
+
 	defaultFileName: 'index.js',
 	defaultFileContent,
 	defaultProjectLanguage: 'Javascript',
+
 	defaultTheme: 'Dracula',
 	defaultFontSize: 16,
 	defaultFontFamily: 'Space Mono',
 	defaultShowGitHubCorner: true,
+
+	visibleTabs: [VIEWS.FILES, VIEWS.CHATS, VIEWS.COPILOT, VIEWS.RUN, VIEWS.CLIENTS, VIEWS.SETTINGS],
+	showDrawingToggle: true,
 	interfaceColors: {
 		dark: "#212429",
 		darkHover: "#3D404A",

--- a/client/src/config/defaults.ts
+++ b/client/src/config/defaults.ts
@@ -1,6 +1,18 @@
+const defaultFileContent = `function sayHi() {
+  console.log("👋 Hello world");
+}
+sayHi()`;
+
 const config = {
 	backendUrl: 'http://localhost:3000',
 	pistonApiUrl: 'http://localhost:2000/api/v2',
+	defaultFileName: 'index.js',
+	defaultFileContent,
+	defaultProjectLanguage: 'Javascript',
+	defaultTheme: 'Dracula',
+	defaultFontSize: 16,
+	defaultFontFamily: 'Space Mono',
+	defaultShowGitHubCorner: true,
 }
 
 export default config

--- a/client/src/config/defaults.ts
+++ b/client/src/config/defaults.ts
@@ -1,5 +1,6 @@
 const config = {
 	backendUrl: 'http://localhost:3000',
+	pistonApiUrl: 'http://localhost:2000/api/v2',
 }
 
 export default config

--- a/client/src/config/defaults.ts
+++ b/client/src/config/defaults.ts
@@ -1,0 +1,5 @@
+const config = {
+}
+
+export default config
+export type Config = typeof config

--- a/client/src/config/defaults.ts
+++ b/client/src/config/defaults.ts
@@ -1,4 +1,5 @@
 const config = {
+	backendUrl: 'http://localhost:3000',
 }
 
 export default config

--- a/client/src/config/index.ts
+++ b/client/src/config/index.ts
@@ -1,0 +1,7 @@
+import defaults from './defaults'
+import overrides from './user'
+
+const config = { ...defaults, ...overrides }
+
+export default config
+export type { Config } from './defaults'

--- a/client/src/config/user.sample.ts
+++ b/client/src/config/user.sample.ts
@@ -1,0 +1,6 @@
+import type { Config } from './defaults'
+
+const overrides: Partial<Config> = {
+}
+
+export default overrides

--- a/client/src/context/FileContext.tsx
+++ b/client/src/context/FileContext.tsx
@@ -652,6 +652,15 @@ function FileContextProvider({ children }: { children: ReactNode }) {
         [activeFile, drawingData, fileStructure, openFiles, setUsers, socket],
     )
 
+    const handleJoinAccepted = useCallback(
+        ({ isNewRoom }: { isNewRoom: boolean }) => {
+            if (isNewRoom) {
+                socket.emit(SocketEvent.SEED_FILE_STRUCTURE, { fileStructure })
+            }
+        },
+        [fileStructure, socket],
+    )
+
     const handleFileStructureSync = useCallback(
         ({
             fileStructure,
@@ -744,6 +753,7 @@ function FileContextProvider({ children }: { children: ReactNode }) {
 
     useEffect(() => {
         socket.once(SocketEvent.SYNC_FILE_STRUCTURE, handleFileStructureSync)
+        socket.on(SocketEvent.JOIN_ACCEPTED, handleJoinAccepted)
         socket.on(SocketEvent.USER_JOINED, handleUserJoined)
         socket.on(SocketEvent.DIRECTORY_CREATED, handleDirCreated)
         socket.on(SocketEvent.DIRECTORY_UPDATED, handleDirUpdated)
@@ -755,6 +765,7 @@ function FileContextProvider({ children }: { children: ReactNode }) {
         socket.on(SocketEvent.FILE_DELETED, handleFileDeleted)
 
         return () => {
+            socket.off(SocketEvent.JOIN_ACCEPTED)
             socket.off(SocketEvent.USER_JOINED)
             socket.off(SocketEvent.DIRECTORY_CREATED)
             socket.off(SocketEvent.DIRECTORY_UPDATED)
@@ -775,6 +786,7 @@ function FileContextProvider({ children }: { children: ReactNode }) {
         handleFileRenamed,
         handleFileStructureSync,
         handleFileUpdated,
+        handleJoinAccepted,
         handleUserJoined,
         socket,
     ])

--- a/client/src/context/SettingContext.tsx
+++ b/client/src/context/SettingContext.tsx
@@ -1,3 +1,4 @@
+import config from "@/config"
 import useLocalStorage from "@/hooks/useLocalStorage"
 import {
     Settings,
@@ -24,11 +25,11 @@ export const useSettings = (): SettingsContextType => {
 }
 
 const defaultSettings: Settings = {
-    theme: "Dracula",
-    language: "Javascript",
-    fontSize: 16,
-    fontFamily: "Space Mono",
-    showGitHubCorner: true,
+    theme: config.defaultTheme,
+    language: config.defaultProjectLanguage,
+    fontSize: config.defaultFontSize,
+    fontFamily: config.defaultFontFamily,
+    showGitHubCorner: config.defaultShowGitHubCorner,
 }
 
 function SettingContextProvider({ children }: { children: ReactNode }) {

--- a/client/src/context/SocketContext.tsx
+++ b/client/src/context/SocketContext.tsx
@@ -1,3 +1,4 @@
+import config from "@/config"
 import { DrawingData } from "@/types/app"
 import {
     SocketContext as SocketContextType,
@@ -27,8 +28,6 @@ export const useSocket = (): SocketContextType => {
     return context
 }
 
-const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000"
-
 const SocketProvider = ({ children }: { children: ReactNode }) => {
     const {
         users,
@@ -40,7 +39,7 @@ const SocketProvider = ({ children }: { children: ReactNode }) => {
     } = useAppContext()
     const socket: Socket = useMemo(
         () =>
-            io(BACKEND_URL, {
+            io(config.backendUrl, {
                 reconnectionAttempts: 2,
             }),
         [],

--- a/client/src/types/socket.ts
+++ b/client/src/types/socket.ts
@@ -27,6 +27,7 @@ enum SocketEvent {
     REQUEST_DRAWING = "request-drawing",
     SYNC_DRAWING = "sync-drawing",
     DRAWING_UPDATE = "drawing-update",
+    SEED_FILE_STRUCTURE = "seed-file-structure",
 }
 
 interface SocketContext {

--- a/client/src/utils/file.ts
+++ b/client/src/utils/file.ts
@@ -1,11 +1,6 @@
+import config from "@/config"
 import { FileSystemItem, Id } from "@/types/file"
 import { v4 as uuidv4 } from "uuid"
-
-const initialCode = `function sayHi() {
-  console.log("👋 Hello world");
-}
-
-sayHi()`
 
 export const initialFileStructure: FileSystemItem = {
     name: "root",
@@ -15,8 +10,8 @@ export const initialFileStructure: FileSystemItem = {
         {
             id: uuidv4(),
             type: "file",
-            name: "index.js",
-            content: initialCode,
+            name: config.defaultFileName,
+            content: config.defaultFileContent,
         },
     ],
 }

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -1,15 +1,10 @@
-/** @type {import('tailwindcss').Config} */
+import config from "./src/config"
+
 export default {
     content: ["./src/**/*.{jsx,tsx}", "./*.html"],
     theme: {
         extend: {
-            colors: {
-                dark: "#212429",
-                darkHover: "#3D404A",
-                light: "#f5f5f5",
-                primary: "#39E079",
-                danger: "#ef4444",
-            },
+            colors: config.interfaceColors,
             fontFamily: {
                 poppins: ["Poppins", "sans-serif"],
             },

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,6 +4,16 @@ import http from "http"
 import cors from "cors"
 import { SocketEvent, SocketId } from "./types/socket"
 import { USER_CONNECTION_STATUS, User } from "./types/user"
+import {
+	getRoot,
+	saveRoot,
+	findFirstFile,
+	applyNodeRenamed,
+	applyNodeDeleted,
+	applyNodeCreated,
+	applyFileUpdated,
+	applyDirectoryUpdated,
+} from "./sessionStore"
 import { Server } from "socket.io"
 import path from "path"
 
@@ -80,7 +90,20 @@ io.on("connection", (socket) => {
 		socket.join(roomId)
 		socket.broadcast.to(roomId).emit(SocketEvent.USER_JOINED, { user })
 		const users = getUsersInRoom(roomId)
-		io.to(socket.id).emit(SocketEvent.JOIN_ACCEPTED, { user, users })
+		const existingRoot = getRoot(roomId)
+		io.to(socket.id).emit(SocketEvent.JOIN_ACCEPTED, {
+			user, users, isNewRoom: !existingRoot,
+		})
+
+		// If a saved session exists, send it to the new client
+		if (existingRoot) {
+			const firstFile = findFirstFile(existingRoot)
+			io.to(socket.id).emit(SocketEvent.SYNC_FILE_STRUCTURE, {
+				fileStructure: existingRoot,
+				openFiles: firstFile ? [firstFile] : [],
+				activeFile: firstFile ?? null,
+			})
+		}
 	})
 
 	socket.on("disconnecting", () => {
@@ -94,7 +117,17 @@ io.on("connection", (socket) => {
 		socket.leave(roomId)
 	})
 
-	// Handle file actions
+	// Handle file structure seeding (first client in a new room)
+	socket.on(
+		SocketEvent.SEED_FILE_STRUCTURE,
+		({ fileStructure }) => {
+			const roomId = getRoomId(socket.id)
+			if (!roomId || getRoot(roomId)) return
+			saveRoot(roomId, fileStructure)
+		}
+	)
+
+	// Handle file structure sync (relay to a specific socket)
 	socket.on(
 		SocketEvent.SYNC_FILE_STRUCTURE,
 		({ fileStructure, openFiles, activeFile, socketId }) => {
@@ -111,6 +144,7 @@ io.on("connection", (socket) => {
 		({ parentDirId, newDirectory }) => {
 			const roomId = getRoomId(socket.id)
 			if (!roomId) return
+			applyNodeCreated(roomId, parentDirId, newDirectory)
 			socket.broadcast.to(roomId).emit(SocketEvent.DIRECTORY_CREATED, {
 				parentDirId,
 				newDirectory,
@@ -121,6 +155,7 @@ io.on("connection", (socket) => {
 	socket.on(SocketEvent.DIRECTORY_UPDATED, ({ dirId, children }) => {
 		const roomId = getRoomId(socket.id)
 		if (!roomId) return
+		applyDirectoryUpdated(roomId, dirId, children)
 		socket.broadcast.to(roomId).emit(SocketEvent.DIRECTORY_UPDATED, {
 			dirId,
 			children,
@@ -130,6 +165,7 @@ io.on("connection", (socket) => {
 	socket.on(SocketEvent.DIRECTORY_RENAMED, ({ dirId, newName }) => {
 		const roomId = getRoomId(socket.id)
 		if (!roomId) return
+		applyNodeRenamed(roomId, dirId, newName)
 		socket.broadcast.to(roomId).emit(SocketEvent.DIRECTORY_RENAMED, {
 			dirId,
 			newName,
@@ -139,6 +175,7 @@ io.on("connection", (socket) => {
 	socket.on(SocketEvent.DIRECTORY_DELETED, ({ dirId }) => {
 		const roomId = getRoomId(socket.id)
 		if (!roomId) return
+		applyNodeDeleted(roomId, dirId)
 		socket.broadcast
 			.to(roomId)
 			.emit(SocketEvent.DIRECTORY_DELETED, { dirId })
@@ -147,6 +184,7 @@ io.on("connection", (socket) => {
 	socket.on(SocketEvent.FILE_CREATED, ({ parentDirId, newFile }) => {
 		const roomId = getRoomId(socket.id)
 		if (!roomId) return
+		applyNodeCreated(roomId, parentDirId, newFile)
 		socket.broadcast
 			.to(roomId)
 			.emit(SocketEvent.FILE_CREATED, { parentDirId, newFile })
@@ -155,6 +193,7 @@ io.on("connection", (socket) => {
 	socket.on(SocketEvent.FILE_UPDATED, ({ fileId, newContent }) => {
 		const roomId = getRoomId(socket.id)
 		if (!roomId) return
+		applyFileUpdated(roomId, fileId, newContent)
 		socket.broadcast.to(roomId).emit(SocketEvent.FILE_UPDATED, {
 			fileId,
 			newContent,
@@ -164,6 +203,7 @@ io.on("connection", (socket) => {
 	socket.on(SocketEvent.FILE_RENAMED, ({ fileId, newName }) => {
 		const roomId = getRoomId(socket.id)
 		if (!roomId) return
+		applyNodeRenamed(roomId, fileId, newName)
 		socket.broadcast.to(roomId).emit(SocketEvent.FILE_RENAMED, {
 			fileId,
 			newName,
@@ -173,6 +213,7 @@ io.on("connection", (socket) => {
 	socket.on(SocketEvent.FILE_DELETED, ({ fileId }) => {
 		const roomId = getRoomId(socket.id)
 		if (!roomId) return
+		applyNodeDeleted(roomId, fileId)
 		socket.broadcast.to(roomId).emit(SocketEvent.FILE_DELETED, { fileId })
 	})
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,7 @@
+// Loaded first so other modules can use configured env vars at import time
+require("dotenv").config()
+
 import express, { Response, Request } from "express"
-import dotenv from "dotenv"
 import http from "http"
 import cors from "cors"
 import { SocketEvent, SocketId } from "./types/socket"
@@ -13,11 +15,11 @@ import {
 	applyNodeCreated,
 	applyFileUpdated,
 	applyDirectoryUpdated,
+	startSessionTimer,
+	cancelSessionTimer,
 } from "./sessionStore"
 import { Server } from "socket.io"
 import path from "path"
-
-dotenv.config()
 
 const app = express()
 
@@ -88,6 +90,7 @@ io.on("connection", (socket) => {
 		}
 		userSocketMap.push(user)
 		socket.join(roomId)
+		cancelSessionTimer(roomId)  // Cancel pending cleanup if room was empty
 		socket.broadcast.to(roomId).emit(SocketEvent.USER_JOINED, { user })
 		const users = getUsersInRoom(roomId)
 		const existingRoot = getRoot(roomId)
@@ -115,6 +118,9 @@ io.on("connection", (socket) => {
 			.emit(SocketEvent.USER_DISCONNECTED, { user })
 		userSocketMap = userSocketMap.filter((u) => u.socketId !== socket.id)
 		socket.leave(roomId)
+
+		// Start cleanup timer if room is now empty
+		if (getUsersInRoom(roomId).length === 0) startSessionTimer(roomId)
 	})
 
 	// Handle file structure seeding (first client in a new room)

--- a/server/src/sessionStore.ts
+++ b/server/src/sessionStore.ts
@@ -1,0 +1,87 @@
+import { FileSystemItem, Id } from "./types/file"
+
+const roots = new Map<string, FileSystemItem>()
+
+function findNodeById(root: FileSystemItem, id: Id): FileSystemItem | null {
+	if (root.id === id) return root
+	if (root.type === "directory" && root.children) {
+		for (const child of root.children) {
+			const found = findNodeById(child, id)
+			if (found) return found
+		}
+	}
+	return null
+}
+
+function findParentById(root: FileSystemItem, id: Id): FileSystemItem | null {
+	if (root.type !== "directory" || !root.children) return null
+	if (root.children.some(c => c.id === id)) return root
+	for (const child of root.children) {
+		if (child.type === "directory") {
+			const found = findParentById(child, id)
+			if (found) return found
+		}
+	}
+	return null
+}
+
+export function findFirstFile(root: FileSystemItem): FileSystemItem | null {
+	if (root.type === "file") return root
+	if (root.type === "directory" && root.children) {
+		for (const child of root.children) {
+			const found = findFirstFile(child)
+			if (found) return found
+		}
+	}
+	return null
+}
+
+export function getRoot(roomId: string): FileSystemItem | null {
+	const root = roots.get(roomId)
+	return root ? structuredClone(root) : null
+}
+
+export function saveRoot(roomId: string, root: FileSystemItem): void {
+	roots.set(roomId, structuredClone(root))
+}
+
+export function applyNodeCreated(roomId: string, parentDirId: Id, newNode: FileSystemItem): void {
+	const root = roots.get(roomId)
+	if (!root) return
+	const parent = findNodeById(root, parentDirId)
+	if (!parent || parent.type !== "directory") return
+	if (!parent.children) parent.children = []
+	parent.children.push(newNode)
+}
+
+export function applyNodeRenamed(roomId: string, nodeId: Id, newName: string): void {
+	const root = roots.get(roomId)
+	if (!root) return
+	const node = findNodeById(root, nodeId)
+	if (!node) return
+	node.name = newName
+}
+
+export function applyNodeDeleted(roomId: string, nodeId: Id): void {
+	const root = roots.get(roomId)
+	if (!root) return
+	const parent = findParentById(root, nodeId)
+	if (!parent || !parent.children) return
+	parent.children = parent.children.filter(c => c.id !== nodeId)
+}
+
+export function applyFileUpdated(roomId: string, fileId: Id, newContent: string): void {
+	const root = roots.get(roomId)
+	if (!root) return
+	const file = findNodeById(root, fileId)
+	if (!file || file.type !== "file") return
+	file.content = newContent
+}
+
+export function applyDirectoryUpdated(roomId: string, dirId: Id, children: FileSystemItem[]): void {
+	const root = roots.get(roomId)
+	if (!root) return
+	const dir = findNodeById(root, dirId)
+	if (!dir || dir.type !== "directory") return
+	dir.children = children
+}

--- a/server/src/sessionStore.ts
+++ b/server/src/sessionStore.ts
@@ -2,6 +2,38 @@ import { FileSystemItem, Id } from "./types/file"
 
 const roots = new Map<string, FileSystemItem>()
 
+function parseSessionTTL(): number {
+	const raw = process.env.SESSION_TTL
+	if (raw !== "") {
+		const parsed = Number(raw)
+		if (parsed >= 0) return parsed
+	}
+	console.warn(`Invalid SESSION_TTL "${raw}", defaulting to 60s`)
+	return 60
+}
+
+const sessionTTL = parseSessionTTL()
+
+const sessionTimers = new Map<string, NodeJS.Timeout>()
+
+export function startSessionTimer(roomId: string): void {
+	if (sessionTTL === Infinity || sessionTTL === 0) return
+	cancelSessionTimer(roomId)
+	const timer = setTimeout(() => {
+		roots.delete(roomId)
+		sessionTimers.delete(roomId)
+	}, sessionTTL * 1000)
+	sessionTimers.set(roomId, timer)
+}
+
+export function cancelSessionTimer(roomId: string): void {
+	const timer = sessionTimers.get(roomId)
+	if (timer) {
+		clearTimeout(timer)
+		sessionTimers.delete(roomId)
+	}
+}
+
 function findNodeById(root: FileSystemItem, id: Id): FileSystemItem | null {
 	if (root.id === id) return root
 	if (root.type === "directory" && root.children) {
@@ -42,6 +74,7 @@ export function getRoot(roomId: string): FileSystemItem | null {
 }
 
 export function saveRoot(roomId: string, root: FileSystemItem): void {
+	if (sessionTTL === 0) return
 	roots.set(roomId, structuredClone(root))
 }
 

--- a/server/src/types/file.ts
+++ b/server/src/types/file.ts
@@ -1,0 +1,11 @@
+type Id = string
+
+interface FileSystemItem {
+    id: Id
+    name: string
+    type: "file" | "directory"
+    children?: FileSystemItem[]
+    content?: string
+}
+
+export { FileSystemItem, Id }

--- a/server/src/types/socket.ts
+++ b/server/src/types/socket.ts
@@ -27,6 +27,7 @@ enum SocketEvent {
 	REQUEST_DRAWING = "request-drawing",
 	SYNC_DRAWING = "sync-drawing",
 	DRAWING_UPDATE = "drawing-update",
+	SEED_FILE_STRUCTURE = "seed-file-structure",
 }
 
 interface SocketContext {


### PR DESCRIPTION
### Protocol changes
- JOIN_ACCEPTED payload now includes isNewRoom: boolean, signaling whether a saved session exists for the room.
- New client-to-server event SEED_FILE_STRUCTURE allows the first client in a new room to provide the initial file tree.
- When a saved session exists, the server sends SYNC_FILE_STRUCTURE to the joining client alongside JOIN_ACCEPTED.

### How it works
1. First client joins a new room and sends SEED_FILE_STRUCTURE with its file tree; the server stores it.
2. Subsequent mutations are applied to the stored tree as they occur.
3. When a room becomes empty, a cleanup timer (default 60 seconds) starts. If a user rejoins before it fires, the timer is cancelled and the saved tree is sent to the new client.
4. If the timer expires, the session is discarded.

### Note
This code has been tested in a live environment and works as expected.